### PR TITLE
Corrected ON_Mesh initial face buffer

### DIFF
--- a/PumaRhino/PRTUtilityModels.cpp
+++ b/PumaRhino/PRTUtilityModels.cpp
@@ -61,7 +61,7 @@ GeneratedModel::GeneratedModel(const size_t& initialShapeIdx, const Model& model
 
 const ON_Mesh GeneratedModel::toON_Mesh(const ModelPart& modelPart) const 
 {
-	ON_Mesh mesh(static_cast<int>(modelPart.mUVCounts.size()), static_cast<int>(modelPart.mIndices.size()), true, true);
+	ON_Mesh mesh(static_cast<int>(modelPart.mFaces.size()), static_cast<int>(modelPart.mIndices.size()), true, true);
 
 	// Set the initial shape id.
 	mesh.SetUserString(INIT_SHAPE_ID_KEY.c_str(), std::to_wstring(mInitialShapeIndex).c_str());


### PR DESCRIPTION
Changed the face buffer initial size to the correct number. After thinking about it a bit more, I think `mIndices` is the correct size for the correct component. `mVertices.size() / 3` can be smaller than `mIndices.size()` because of vertex re-usage. However, `mIndices.size()` will be the final number of vertices in the final `ON_Mesh` object, which can be seen in from the loop located just below:
```
// Duplicate vertices
for (size_t v_id = 0; v_id < modelPart.mIndices.size(); ++v_id) {
  auto index = modelPart.mIndices[v_id];
  mesh.SetVertex(static_cast<int>(v_id), ON_3dPoint(modelPart.mVertices[index * 3], modelPart.mVertices[index * 3 + 2], modelPart.mVertices[index * 3 + 1]));
  mesh.SetVertexNormal(static_cast<int>(v_id), ON_3dVector(modelPart.mNormals[index * 3], modelPart.mNormals[index * 3 + 2], modelPart.mNormals[index * 3 + 1]));
}
```