### PR TITLE
Fix a crash when trying to output null for generated meshes.

### DIFF
--- a/PumaGrasshopper/ComponentPuma.cs
+++ b/PumaGrasshopper/ComponentPuma.cs
@@ -212,8 +212,11 @@ namespace PumaGrasshopper
                 DA.SetDataTree(1, materials);
             }
 
-            OutputReports(DA, generatedMeshes);
-            DA.SetDataTree(0, generatedMeshes);
+            if (generatedMeshes != null)
+            {
+                OutputReports(DA, generatedMeshes);
+                DA.SetDataTree(0, generatedMeshes);
+            }
         }
 
         protected override void AppendAdditionalComponentMenuItems(ToolStripDropDown menu)


### PR DESCRIPTION
A crash could happen when no mesh was generated. I added a test to avoid trying to extract the reports in case of `generatedMeshes` being null.