### PR TITLE
improve input shape conversion

### DIFF
--- a/PumaGrasshopper/ComponentPuma.cs
+++ b/PumaGrasshopper/ComponentPuma.cs
@@ -406,7 +406,6 @@ namespace PumaGrasshopper
             }
 
             mesh.Vertices.UseDoublePrecisionVertices = true;
-            mesh.Faces.ConvertTrianglesToQuads(Rhino.RhinoMath.ToRadians(2), .875);
 
             return mesh;
         }


### PR DESCRIPTION
Two main issues have been adressed:
* Unstable winding order of resulting quad polygons from Rhino rectangles
* Too many polygons generated from simple box breps and quad surfaces

Test with rule:
````
Init -->
	comp(f) { all: F }
	
F -->
	setupProjection(0, scope.xy, scope.sx, scope.sy)
	projectUV(0)
	texture("builtin:uvtest.png")
````

![image](https://user-images.githubusercontent.com/1630632/128021442-40430740-aada-448f-9c74-0e9def3e7a48.png)
