### PR TITLE
Bump PRT to version 3.1.9666

### DIFF
--- a/PumaDependencies/PumaDependencies.vcxproj
+++ b/PumaDependencies/PumaDependencies.vcxproj
@@ -14,7 +14,7 @@
     <ProjectName>PumaDependencies</ProjectName>
   </PropertyGroup>
   <PropertyGroup>
-    <PRTUrl>https://github.com/Esri/cityengine-sdk/releases/download/3.0.8905/esri_ce_sdk-3.0.8905-win10-vc1427-x86_64-rel-opt.zip</PRTUrl>
+    <PRTUrl>https://github.com/Esri/cityengine-sdk/releases/download/3.1.9666/esri_ce_sdk-3.1.9666-win10-vc1427-x86_64-rel-opt.zip</PRTUrl>
     <OutputDirectory>$(SolutionDir)build\</OutputDirectory>
     <DependencyDir>$(SolutionDir)deps\</DependencyDir>
   </PropertyGroup>


### PR DESCRIPTION
Issue: https://devtopia.esri.com/Zurich-R-D-Center/ce-plugin-crew/issues/145

This PR simply bumps PRT to the latest release (v3.1.9666).

No other changes were needed.

I tested with the release showcase scene. It worked like a charm.