### PR TITLE
Update PRT to version 3.3.11173 (CE 2025.0)

### DIFF
--- a/PumaDependencies/PumaDependencies.vcxproj
+++ b/PumaDependencies/PumaDependencies.vcxproj
@@ -14,7 +14,7 @@
     <ProjectName>Dependencies</ProjectName>
   </PropertyGroup>
   <PropertyGroup>
-    <PRTUrl>https://github.com/Esri/cityengine-sdk/releases/download/3.2.10650/esri_ce_sdk-3.2.10650-win10-vc1437-x86_64-rel-opt.zip</PRTUrl>
+    <PRTUrl>https://github.com/Esri/cityengine-sdk/releases/download/3.3.11173/esri_ce_sdk-3.3.11173-win10-vc1438-x86_64-rel-opt.zip</PRTUrl>
     <OutputDirectory>$(SolutionDir)build\</OutputDirectory>
     <DependencyDir>$(SolutionDir)deps\</DependencyDir>
   </PropertyGroup>


### PR DESCRIPTION
Issue: [Zurich-R-D-Center/ce-plugin-crew#215](https://devtopia.esri.com/Zurich-R-D-Center/ce-plugin-crew/issues/215)

### Description

This PR updates PRT to the version 3.3.11173 used by CityEngine 2025.0.

No other change were necessary.